### PR TITLE
Event examples

### DIFF
--- a/app/Listeners/DeleteImageListener.php
+++ b/app/Listeners/DeleteImageListener.php
@@ -22,9 +22,8 @@ class DeleteImageListener
         // Search for usages of the file
         $used = FilePath::where('path', $publicFilePath)->get();
 
-        if($used) {
-            // the image is in use, create a response message
-
+        if(count($used) > 0) {
+            // The image is in use, create a response message
             $message = $this->formatMessage($used);
 
             // Die with response message

--- a/app/Listeners/HasUploadedImageListener.php
+++ b/app/Listeners/HasUploadedImageListener.php
@@ -1,0 +1,22 @@
+<?php
+namespace App\Listeners;
+
+use Unisharp\Laravelfilemanager\Events\ImageWasUploaded;
+use App\FilePath;
+
+
+class HasUploadedImageListener
+{
+    /**
+     * Handle the event.
+     *
+     * @param  ImageWasUploaded  $event
+     * @return void
+     */
+    public function handle(ImageWasUploaded $event)
+    {
+        // Get te public path to the file and save it to the database
+        $publicFilePath = str_replace(public_path(), "", $event->path());
+        FilePath::create(['path' => $publicFilePath]);
+    }
+}

--- a/app/Listeners/IsUploadingImageListener.php
+++ b/app/Listeners/IsUploadingImageListener.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Listeners;
+
+use Unisharp\Laravelfilemanager\Events\ImageIsUploading;
+use Illuminate\Support\Facades\Auth;
+
+class IsUploadingImageListener
+{
+    /**
+     * Handle the event.
+     *
+     * @param  ImageIsUploading  $event
+     * @return void
+     */
+    public function handle(ImageIsUploading $event)
+    {
+        if (!Auth::guard('web')->check()) die('<p>You need to be logged in in order to upload files.</p>');
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -7,8 +7,13 @@ use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvi
 
 use Unisharp\Laravelfilemanager\Events\ImageIsDeleting;
 use Unisharp\Laravelfilemanager\Events\ImageIsRenaming;
+use Unisharp\Laravelfilemanager\Events\ImageIsUploading;
+use Unisharp\Laravelfilemanager\Events\ImageWasUploaded;
 use App\Listeners\DeleteImageListener;
 use App\Listeners\RenameImageListener;
+use App\Listeners\IsUploadingImageListener;
+use App\Listeners\HasUploadedImageListener;
+
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -26,6 +31,12 @@ class EventServiceProvider extends ServiceProvider
         ],
         ImageIsRenaming::class => [
             RenameImageListener::class
+        ],
+        ImageIsUploading::class => [
+            IsUploadingImageListener::class
+        ],
+        ImageWasUploaded::class => [
+            HasUploadedImageListener::class
         ]
     ];
 

--- a/readme.md
+++ b/readme.md
@@ -7,9 +7,19 @@ This project already integrated [unisharp/laravel-filemanager](https://github.co
 3. `php artisan serve`
 4. Go to your browser and visit `localhost:8000/laravel-filemanager/demo`
 
-## Eventing examples
+## Event usage examples
 This project provides examples on how to use the eventing system with [laravel-filemanager](https://github.com/UniSharp/laravel-filemanager).
-The following events provide an example implementation:
+
+#### ImageIsUploading
+This event is fired before an image is saved. The event listener in [App\Listeners\IsUploadingImageListener](https://github.com/UniSharp/laravel-filemanager-demo-events/blob/master/app/Listeners/IsUploadingImageListener.php) does the following:
+1. Checks if hte user is currently logged in, if not aborts the request. 
+
+*Note: If you are using this example project you are automatically logged in, try playing around with it*
+
+#### ImageWasUploaded
+This event is fired before an image is saved. The event listener in [App\Listeners\HasUploadedImageListener](https://github.com/UniSharp/laravel-filemanager-demo-events/blob/master/app/Listeners/HasUploadedImageListener.php) does the following:
+1. Extracts the file path of the file that was just uploaded
+2. Saves the file path to the database
 
 #### ImageIsDeleting
 This event is fired before an image is deleted. The event listener in [App\Listeners\DeleteImageListener](https://github.com/UniSharp/laravel-filemanager-demo-events/blob/master/app/Listeners/DeleteImageListener.php) does the following:


### PR DESCRIPTION
Added before and after upload listeners.

Before a file is uploaded it checks if the current user is logged in. (this is always the case but made this for demonstration purpose)

After a file is uploaded it saves the file path to the database.